### PR TITLE
ci(action): load `ATLAS_URI` from GitHub Secrets

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -37,6 +37,7 @@ jobs:
           npm start &
         env:
           NODE_ENV: production
+          ATLAS_URI: ${{ secrets.ATLAS_URI }}
 
       - name: Build Angular project
         run: |


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to securely load the `ATLAS_URI` environment variable directly from GitHub Secrets. The updated configuration ensures the server has the necessary MongoDB connection string during the build and prerendering process.