### PR TITLE
fix(build): remove component with API dependency

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,23 +24,15 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
 
-      - name: Install dependencies
+      - name: Install client dependencies
         run: |
           cd client
           npm ci
-          cd ../server
-          npm ci
 
-      - name: Start API Server and Build Angular Project
+      - name: Build Angular project
         run: |
-          cd server
-          npm start &
-          cd ../client
-          sleep 5
+          cd client
           npm run build
-        env:
-          NODE_ENV: production
-          ATLAS_URI: ${{ secrets.ATLAS_URI }}
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -31,19 +31,16 @@ jobs:
           cd ../server
           npm ci
 
-      - name: Start API Server
+      - name: Start API Server and Build Angular Project
         run: |
           cd server
           npm start &
+          cd ../client
+          sleep 5
+          npm run build
         env:
           NODE_ENV: production
           ATLAS_URI: ${{ secrets.ATLAS_URI }}
-
-      - name: Build Angular project
-        run: |
-          cd client
-          sleep 5
-          npm run build
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/client/src/app/todo-list/todo-list.component.html
+++ b/client/src/app/todo-list/todo-list.component.html
@@ -81,5 +81,3 @@
     }
   </div>
 </ng-template>
-
-<app-presets />

--- a/client/src/app/todo-list/todo-list.component.ts
+++ b/client/src/app/todo-list/todo-list.component.ts
@@ -16,7 +16,6 @@ import {
 import { NgTemplateOutlet } from '@angular/common';
 import { TodoItemComponent } from '../todo-item/todo-item.component';
 import { ModeToggleComponent } from '../mode-toggle/mode-toggle.component';
-import { PresetsComponent } from '../presets/presets.component';
 
 @Component({
   selector: 'app-todo-list',
@@ -26,7 +25,6 @@ import { PresetsComponent } from '../presets/presets.component';
     CdkDropList,
     TodoItemComponent,
     ModeToggleComponent,
-    PresetsComponent,
   ],
   templateUrl: './todo-list.component.html',
   styleUrl: './todo-list.component.scss',


### PR DESCRIPTION
This PR removes the affected component from the parent component to address build failures in the CI process. The removed component references an API endpoint (`http://localhost:5200/presets`) that is unavailable during the build, causing prerendering errors.

This is a temporary measure to unblock the CI pipeline. A long-term solution will involve properly handling environment-specific API endpoints or mock data during the build process to avoid similar issues.