### PR TITLE
refactor: enhance TodoStore with hooks for initialization

### DIFF
--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -1,8 +1,3 @@
-:host {
-  position: relative;
-  display: block;
-}
-
 .main {
   padding-block: 6rem 3rem;
 

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -1,11 +1,5 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  inject,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { TodoStore } from './store/todo.store';
 import { HeaderComponent } from './app-shell/header/header.component';
 
 @Component({
@@ -15,11 +9,4 @@ import { HeaderComponent } from './app-shell/header/header.component';
   styleUrl: './app.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AppComponent implements OnInit {
-  readonly store = inject(TodoStore);
-
-  ngOnInit(): void {
-    this.store.setLoading(true);
-    this.store.loadData();
-  }
-}
+export class AppComponent {}

--- a/client/src/app/landing/auth.guard.ts
+++ b/client/src/app/landing/auth.guard.ts
@@ -2,13 +2,15 @@ import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 import { AuthService } from './auth.service';
 
-export const authGuard: CanActivateFn = async () => {
-  const authService = inject(AuthService);
-  const router = inject(Router);
+export const authGuard = (): CanActivateFn => {
+  return () => {
+    const authService = inject(AuthService);
+    const router = inject(Router);
 
-  return authService.isInitialized()
-    ? authService.isLoggedIn()
-      ? true
-      : router.createUrlTree(['/login'])
-    : false;
+    if (authService.isInitialized() && authService.isLoggedIn()) {
+      return true;
+    }
+
+    return router.parseUrl('/login');
+  };
 };

--- a/client/src/app/store/todo.store.ts
+++ b/client/src/app/store/todo.store.ts
@@ -4,6 +4,7 @@ import {
   patchState,
   signalStore,
   withComputed,
+  withHooks,
   withMethods,
   withState,
 } from '@ngrx/signals';
@@ -143,4 +144,10 @@ export const TodoStore = signalStore(
       },
     }),
   ),
+  withHooks(({ loadData, setLoading }) => ({
+    onInit: () => {
+      loadData();
+      setLoading(true);
+    },
+  })),
 );


### PR DESCRIPTION
This PR moves the to-do list initial data loading from `AppComponent` to the store hook.