### PR TITLE
refactor(ssr): migrate from CommonEngine to AngularNodeAppEngine

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -19,6 +19,7 @@
           "builder": "@angular/build:application",
           "options": {
             "outputPath": "dist",
+            "outputMode": "server",
             "index": "src/index.html",
             "browser": "src/main.ts",
             "tsConfig": "tsconfig.app.json",
@@ -27,7 +28,6 @@
             "styles": ["src/styles.scss"],
             "scripts": [],
             "server": "src/main.server.ts",
-            "prerender": true,
             "ssr": {
               "entry": "server.ts"
             }

--- a/client/src/app/app.config.server.ts
+++ b/client/src/app/app.config.server.ts
@@ -1,9 +1,10 @@
-import { provideServerRendering } from '@angular/ssr';
+import { provideServerRendering, withRoutes } from '@angular/ssr';
 import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
 import { appConfig } from './app.config';
+import { serverRoutes } from './app.routes.server';
 
 const serverConfig: ApplicationConfig = {
-  providers: [provideServerRendering()],
+  providers: [provideServerRendering(withRoutes(serverRoutes))],
 };
 
 export const config = mergeApplicationConfig(appConfig, serverConfig);

--- a/client/src/app/app.routes.server.ts
+++ b/client/src/app/app.routes.server.ts
@@ -1,0 +1,6 @@
+import { RenderMode, ServerRoute } from '@angular/ssr';
+
+export const serverRoutes: ServerRoute[] = [
+  // All routes are client-only to avoid hydration mismatches (theme changes, platform checks)
+  { path: '**', renderMode: RenderMode.Client },
+];

--- a/client/src/app/app.routing.ts
+++ b/client/src/app/app.routing.ts
@@ -1,10 +1,11 @@
 import { Routes } from '@angular/router';
-import { authGuard } from './landing/auth.guard';
+import { authGuard, guestGuard } from './landing/auth.guard';
 
 export const routes: Routes = [
   { path: '', redirectTo: '/dashboard', pathMatch: 'full' },
   {
     path: 'login',
+    canActivate: [guestGuard],
     loadComponent: () =>
       import('./landing/landing.component').then(c => c.LandingComponent),
   },

--- a/client/src/app/dashboard/preset/preset.component.html
+++ b/client/src/app/dashboard/preset/preset.component.html
@@ -42,4 +42,6 @@
   }
 </form>
 
-<p class="info">Drag and drop to reorder list</p>
+@if (!loading()) {
+  <p class="info">Drag and drop to reorder list</p>
+}

--- a/client/src/app/landing/auth.guard.ts
+++ b/client/src/app/landing/auth.guard.ts
@@ -12,3 +12,14 @@ export const authGuard: CanActivateFn = () => {
 
   return router.parseUrl('/login');
 };
+
+export const guestGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (!authService.authenticated()) {
+    return true;
+  }
+
+  return router.parseUrl('/dashboard');
+};

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="app-dark-mode">
   <head>
     <meta charset="utf-8" />
     <title>TodoApp</title>


### PR DESCRIPTION
- Add `outputMode: "server"` to angular.json for proper SSR build
- Replace `CommonEngine` with `AngularNodeAppEngine` in `server.ts`
- Add `app.routes.server.ts` with `RenderMode.Client` for all routes
- Configure `provideServerRendering` with `withRoutes` in `app.config.server.ts`
- Add default theme class to `index.html` for potential SSR styling
- Simplify auth guards and add `guestGuard` for the login page
- Fix the auth service to initialize the login state from `localStorage` directly

All routes use client-side rendering to avoid hydration mismatches caused by theme changes and platform-specific code.